### PR TITLE
Improve freshness logic with hard-session recency

### DIFF
--- a/app/src/main/kotlin/com/endurocoach/Application.kt
+++ b/app/src/main/kotlin/com/endurocoach/Application.kt
@@ -66,6 +66,27 @@ data class LoadSnapshotResponse(
     val series: List<LoadPointResponse>
 )
 
+@Serializable
+data class AthleteProfileResponse(
+    val sportFocus: String,
+    val targetEventName: String,
+    val targetEventDate: String,
+    val maxHr: Int,
+    val restingHr: Int,
+    val onboardingCompleted: Boolean
+)
+
+@Serializable
+data class WorkoutPlanResponse(
+    val session: String,
+    val coachReasoning: String,
+    val generatedAt: String?,
+    val source: String
+)
+
+@Serializable
+data class WorkoutResponse(val workout: WorkoutPlanResponse?)
+
 fun Application.module() {
     install(ContentNegotiation) {
         json()
@@ -475,6 +496,83 @@ fun Application.module() {
 
         get("/api/demo-load") {
             call.respond(mapOf("notice" to "Deprecated endpoint; use /api/load"))
+        }
+
+        get("/api/athlete") {
+            val sessionId = call.request.cookies[SESSION_COOKIE]
+            val session = sessionRegistry.getOrCreate(sessionId)
+            val state = session.dashboardState.read()
+            call.respond(
+                AthleteProfileResponse(
+                    sportFocus = state.onboarding.sportFocus,
+                    targetEventName = state.onboarding.targetEventName,
+                    targetEventDate = state.onboarding.targetEventDate,
+                    maxHr = state.maxHr,
+                    restingHr = state.restingHr,
+                    onboardingCompleted = state.onboarding.completed
+                )
+            )
+        }
+
+        get("/api/workout") {
+            val sessionId = call.request.cookies[SESSION_COOKIE]
+            val session = sessionRegistry.getOrCreate(sessionId)
+            val state = session.dashboardState.read()
+            val workout = state.latestWorkout
+            val plan = workout?.let {
+                WorkoutPlanResponse(
+                    session = it.session,
+                    coachReasoning = it.coachReasoning,
+                    generatedAt = state.generatedAt?.toString(),
+                    source = state.source
+                )
+            }
+            call.respond(WorkoutResponse(workout = plan))
+        }
+
+        get("/robots.txt") {
+            call.respondText(
+                """
+                User-agent: *
+                Allow: /
+
+                User-agent: GPTBot
+                Allow: /
+
+                User-agent: ClaudeBot
+                Allow: /
+
+                User-agent: PerplexityBot
+                Allow: /
+
+                Sitemap: /llms.txt
+                """.trimIndent(),
+                io.ktor.http.ContentType.Text.Plain
+            )
+        }
+
+        get("/llms.txt") {
+            call.respondText(
+                """
+                # Maestro — AI Endurance Coach
+
+                > Maestro analyses your Strava training data and prescribes daily workouts using the Banister impulse-response model and AI language models.
+
+                ## Docs
+
+                - [Privacy Policy](/privacy)
+                - [Terms of Service](/terms)
+
+                ## API
+
+                - [GET /api/load](/api/load): Training load metrics (CTL, ATL, TSB, ACWR, monotony, CTL ramp rate, recent volume) with a daily time-series. Query params: `days` (7–120, default 45), `maxHr` (120–230, default 190), `restingHr` (30–90, default 50). Returns JSON `LoadSnapshotResponse`.
+                - [GET /api/athlete](/api/athlete): Current athlete profile for the session — sport focus, target event name/date, heart-rate profile (maxHr, restingHr), and whether onboarding is complete. Returns JSON `AthleteProfileResponse`.
+                - [GET /api/workout](/api/workout): Most recently generated workout plan for the session — session prescription, coach reasoning, generation timestamp, and data source. Returns JSON `WorkoutPlanResponse`, or `{"workout":null}` when no plan has been generated yet.
+                - [GET /api/strava/status](/api/strava/status): Whether the current session has a connected Strava account. Returns `{"connected": true|false}`.
+                - [GET /health](/health): Liveness probe. Returns plain text `maestro scaffold is running`.
+                """.trimIndent(),
+                io.ktor.http.ContentType.Text.Plain
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/endurocoach/Application.kt
+++ b/app/src/main/kotlin/com/endurocoach/Application.kt
@@ -17,7 +17,9 @@ import com.endurocoach.llm.GeminiConfig
 import com.endurocoach.llm.PerplexityClient
 import com.endurocoach.llm.PerplexityConfig
 import com.endurocoach.routes.DashboardDependencies
+import com.endurocoach.routes.McpDependencies
 import com.endurocoach.routes.installDashboardRoutes
+import com.endurocoach.routes.installMcpRoutes
 import com.endurocoach.session.SESSION_COOKIE
 import com.endurocoach.session.SESSION_MAX_AGE
 import com.endurocoach.session.SessionRegistry
@@ -129,6 +131,15 @@ fun Application.module() {
                         maxHr = maxHr,
                         restingHr = restingHr
                     )
+                }
+            )
+        )
+
+        installMcpRoutes(
+            McpDependencies(
+                sessionRegistry = sessionRegistry,
+                loadProvider = { repo, days, maxHr, restingHr ->
+                    buildLoadSnapshot(repository = repo, days = days, maxHr = maxHr, restingHr = restingHr)
                 }
             )
         )
@@ -563,7 +574,11 @@ fun Application.module() {
                 - [Privacy Policy](/privacy)
                 - [Terms of Service](/terms)
 
-                ## API
+                ## MCP Server
+
+                - [POST /mcp](/mcp): Model Context Protocol (MCP) endpoint implementing the Streamable-HTTP transport (protocol version 2024-11-05). Supports `initialize`, `tools/list`, and `tools/call`. Each tool accepts an optional `sessionId` argument (value of the `enduro_session` cookie); omit it to receive demo data. Tools: `get_training_load`, `get_athlete_profile`, `get_workout_plan`.
+
+                ## REST API
 
                 - [GET /api/load](/api/load): Training load metrics (CTL, ATL, TSB, ACWR, monotony, CTL ramp rate, recent volume) with a daily time-series. Query params: `days` (7–120, default 45), `maxHr` (120–230, default 190), `restingHr` (30–90, default 50). Returns JSON `LoadSnapshotResponse`.
                 - [GET /api/athlete](/api/athlete): Current athlete profile for the session — sport focus, target event name/date, heart-rate profile (maxHr, restingHr), and whether onboarding is complete. Returns JSON `AthleteProfileResponse`.

--- a/app/src/main/kotlin/com/endurocoach/Application.kt
+++ b/app/src/main/kotlin/com/endurocoach/Application.kt
@@ -65,7 +65,18 @@ data class LoadSnapshotResponse(
     val monotony: Double,
     val ctlRampRate: Double,
     val recentVolumeMinutes: Double,
+    val daysSinceLastHardSession: Int? = null,
+    val recentSessions: List<RecentSessionResponse> = emptyList(),
     val series: List<LoadPointResponse>
+)
+
+@Serializable
+data class RecentSessionResponse(
+    val date: String,
+    val name: String,
+    val durationMinutes: Double,
+    val trimp: Double,
+    val intensity: String
 )
 
 @Serializable
@@ -491,6 +502,16 @@ fun Application.module() {
                 monotony = snapshot.monotony,
                 ctlRampRate = snapshot.ctlRampRate,
                 recentVolumeMinutes = snapshot.recentVolumeMinutes,
+                daysSinceLastHardSession = snapshot.daysSinceLastHardSession,
+                recentSessions = snapshot.recentSessions.map {
+                    RecentSessionResponse(
+                        date = it.date.toString(),
+                        name = it.name,
+                        durationMinutes = it.durationMinutes,
+                        trimp = it.trimp,
+                        intensity = it.intensity
+                    )
+                },
                 series = snapshot.series.map {
                     LoadPointResponse(
                         date = it.date.toString(),

--- a/app/src/main/kotlin/com/endurocoach/routes/DashboardRoutes.kt
+++ b/app/src/main/kotlin/com/endurocoach/routes/DashboardRoutes.kt
@@ -368,7 +368,9 @@ fun Route.installDashboardRoutes(dependencies: DashboardDependencies) {
             ctlRampRate = snapshot.ctlRampRate,
             spike10 = snapshot.spike10,
             strain10 = snapshot.strain10,
-            recentPaceProfile = paceProfile
+            recentPaceProfile = paceProfile,
+            daysSinceLastHardSession = snapshot.daysSinceLastHardSession,
+            recentSessions = snapshot.recentSessions
         )
 
         runCatching { dependencies.llmClient.generateWorkoutPlan(request) }
@@ -758,7 +760,13 @@ private fun renderDashboard(
 
     // TSB contextual interpretation (Mujika & Busso research-based ranges)
     val tsb = snapshot.tsb
+    val daysSinceHard = snapshot.daysSinceLastHardSession
+    val hardWithin72h = daysSinceHard != null && daysSinceHard < 3
+    val hardWithin48h = daysSinceHard != null && daysSinceHard < 2
+    val recentHardWithHighFatigue = hardWithin72h && snapshot.atl > snapshot.ctl
     val tsbBadgeClass = when {
+        recentHardWithHighFatigue -> "fatigued"
+        hardWithin48h -> "neutral"
         tsb > 25 -> "fatigued"   // detraining risk
         tsb > 10 -> "fresh"      // tapered / race-ready
         tsb > -10 -> "neutral"   // productive training
@@ -766,6 +774,8 @@ private fun renderDashboard(
         else -> "fatigued"       // overreaching risk
     }
     val tsbBadgeLabel = when {
+        recentHardWithHighFatigue -> "Recovering"
+        hardWithin48h -> "Hold quality"
         tsb > 25 -> "Detraining"
         tsb > 10 -> "Race-ready"
         tsb > 0 -> "Fresh"
@@ -774,6 +784,8 @@ private fun renderDashboard(
         else -> "Overreaching"
     }
     val tsbExplainBase = when {
+        recentHardWithHighFatigue -> "You hit a hard session in the last 72 hours and your acute fatigue is still above fitness. This is a recovery window, not a quality window."
+        hardWithin48h -> "You hit a hard session in the last 48 hours. Even if form looks okay, adaptation is still happening — hold intensity today."
         tsb > 25  -> "You've been very fresh for a while \u2014 if you're not peaking for a race, your fitness may slowly be slipping. Time to add some load back in."
         tsb > 10  -> "You're fresh and fit \u2014 perfect timing for a race or a big quality session. Make the most of it."
         tsb > 0   -> "Feeling good with solid fitness underneath. A great day for a quality effort or a strong long run."
@@ -783,6 +795,8 @@ private fun renderDashboard(
     }
     // Cross-metric awareness: append a relevant secondary signal when it matters
     val tsbCrossMetric = when {
+        hardWithin72h && snapshot.atl > snapshot.ctl -> " Last hard run is too recent for another quality day — keep this session easy."
+        hardWithin72h -> " Last hard run is recent, so bias toward easy aerobic work today."
         snapshot.acwr > 1.5 -> " Your load ratio has spiked \u2014 dial it back today regardless."
         snapshot.acwr > 1.3 && tsb > -10 -> " Your load ratio is creeping up though \u2014 keep an eye on it."
         snapshot.monotony > 2.0 && tsb <= 0  -> " Your training variety is also low \u2014 mix in a different type of session."
@@ -793,6 +807,8 @@ private fun renderDashboard(
 
     // Actionable call-to-action for the hero card
     val tsbCta = when {
+        recentHardWithHighFatigue -> "⛔ Hard effort is too soon. Keep it easy today and reassess tomorrow."
+        hardWithin48h -> "🛌 Protect adaptation — easy aerobic running or rest today, quality tomorrow at the earliest."
         tsb > 25  -> "\u27A1 Get moving \u2014 a solid tempo or threshold session today will rebuild momentum without overdoing it."
         tsb > 10  -> "\u26A1 This is your window. Ask the coach for a race-effort session or hit that hard workout you've been saving."
         tsb > 0   -> "\u2705 Use the freshness \u2014 a quality long run, tempo, or interval session will land well today."
@@ -976,12 +992,16 @@ private fun renderDashboard(
 
     // Hero card supplementary vars
     val tsbHeroClass = when {
+        recentHardWithHighFatigue -> "negative-risk"
+        hardWithin48h -> "negative-ok"
         tsb > 10 -> "positive"
         tsb > 0 -> "neutral"
         tsb > -20 -> "negative-ok"
         else -> "negative-risk"
     }
     val tsbHeroMessage = when {
+        recentHardWithHighFatigue -> "Recent hard run + high fatigue: recover today"
+        hardWithin48h -> "Recent hard run: no quality today"
         tsb > 25 -> "Keep it steady — your fitness base may be fading"
         tsb > 10 -> "Primed to push hard or race"
         tsb > 0 -> "Fresh with solid fitness — a good day to perform"

--- a/app/src/main/kotlin/com/endurocoach/routes/McpRoutes.kt
+++ b/app/src/main/kotlin/com/endurocoach/routes/McpRoutes.kt
@@ -1,0 +1,267 @@
+package com.endurocoach.routes
+
+import com.endurocoach.domain.Activity
+import com.endurocoach.domain.LoadSnapshot
+import com.endurocoach.session.SessionRegistry
+import com.endurocoach.strava.CachedActivityRepository
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlinx.serialization.json.*
+
+private const val MCP_PROTOCOL_VERSION = "2024-11-05"
+private const val SERVER_NAME = "maestro-enduro-coach"
+private const val SERVER_VERSION = "1.0"
+
+/**
+ * Dependencies required by the MCP server routes.
+ *
+ * @param sessionRegistry Used to resolve athlete sessions by ID.
+ * @param loadProvider Computes training-load metrics for a given repository / HR profile / window.
+ *   Parameters: activityRepository, days, maxHr, restingHr.
+ */
+data class McpDependencies(
+    val sessionRegistry: SessionRegistry,
+    val loadProvider: suspend (CachedActivityRepository?, Int, Int, Int) -> Triple<String, LoadSnapshot, List<Activity>>
+)
+
+/**
+ * Registers the MCP (Model Context Protocol) endpoint at POST /mcp.
+ *
+ * Implements the MCP Streamable-HTTP transport (protocol version 2024-11-05).
+ * Notifications (requests without an `id` field) receive 202 Accepted with no body.
+ * All other requests receive a JSON-RPC 2.0 response.
+ *
+ * Exposed tools:
+ *   - get_training_load  — CTL, ATL, TSB, ACWR, monotony, ramp rate + time-series
+ *   - get_athlete_profile — sport focus, target event, HR zones, onboarding status
+ *   - get_workout_plan   — latest AI-generated workout prescription + coach reasoning
+ *
+ * Each tool accepts an optional `sessionId` argument (value of the `enduro_session` cookie).
+ * When omitted the server creates a temporary session backed by demo activity data.
+ */
+fun Route.installMcpRoutes(deps: McpDependencies) {
+    post("/mcp") {
+        val body = call.receiveText()
+        val request = try {
+            Json.parseToJsonElement(body).jsonObject
+        } catch (e: Exception) {
+            call.respondText(jsonRpcError(null, -32700, "Parse error"), ContentType.Application.Json)
+            return@post
+        }
+
+        // JSON-RPC notifications have no "id" — acknowledge without responding
+        if (!request.containsKey("id")) {
+            call.respond(HttpStatusCode.Accepted)
+            return@post
+        }
+
+        val id = request["id"]
+        val method = request["method"]?.jsonPrimitive?.contentOrNull
+        if (method == null) {
+            call.respondText(jsonRpcError(id, -32600, "Invalid Request"), ContentType.Application.Json)
+            return@post
+        }
+
+        val params = request["params"]?.jsonObject ?: JsonObject(emptyMap())
+        val response = when (method) {
+            "initialize" -> handleInitialize(id)
+            "tools/list" -> handleToolsList(id)
+            "tools/call" -> handleToolsCall(id, params, deps)
+            else -> jsonRpcError(id, -32601, "Method not found: $method")
+        }
+        call.respondText(response, ContentType.Application.Json)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Method handlers
+// ---------------------------------------------------------------------------
+
+private fun handleInitialize(id: JsonElement?): String =
+    jsonRpcSuccess(
+        id,
+        buildJsonObject {
+            put("protocolVersion", MCP_PROTOCOL_VERSION)
+            put("capabilities", buildJsonObject { put("tools", JsonObject(emptyMap())) })
+            put("serverInfo", buildJsonObject {
+                put("name", SERVER_NAME)
+                put("version", SERVER_VERSION)
+            })
+        }
+    )
+
+private fun handleToolsList(id: JsonElement?): String {
+    val tools = buildJsonArray {
+        add(
+            toolDef(
+                name = "get_training_load",
+                description = "Retrieve training-load metrics computed from the athlete's activity history " +
+                    "using the Banister impulse-response model: CTL (fitness), ATL (fatigue), TSB (form), " +
+                    "ACWR, monotony, CTL ramp rate, recent volume, and a daily time-series.",
+                properties = buildJsonObject {
+                    put("sessionId", prop("string", "Athlete session ID (value of the enduro_session cookie). Omit for demo data."))
+                    put("days", prop("integer", "Analysis window in days (7–120). Defaults to 45."))
+                    put("maxHr", prop("integer", "Athlete max heart rate bpm (120–230). Defaults to 190."))
+                    put("restingHr", prop("integer", "Athlete resting heart rate bpm (30–90). Defaults to 50."))
+                }
+            )
+        )
+        add(
+            toolDef(
+                name = "get_athlete_profile",
+                description = "Retrieve the athlete's onboarding profile: sport focus, target event name " +
+                    "and date, heart-rate profile (maxHr, restingHr), and whether onboarding is complete.",
+                properties = buildJsonObject {
+                    put("sessionId", prop("string", "Athlete session ID (value of the enduro_session cookie). Omit for demo/default profile."))
+                }
+            )
+        )
+        add(
+            toolDef(
+                name = "get_workout_plan",
+                description = "Retrieve the most recently AI-generated workout plan for the athlete: " +
+                    "session prescription, coach reasoning, generation timestamp, and data source. " +
+                    "Returns null when no plan has been generated yet.",
+                properties = buildJsonObject {
+                    put("sessionId", prop("string", "Athlete session ID (value of the enduro_session cookie). Omit for demo session."))
+                }
+            )
+        )
+    }
+    return jsonRpcSuccess(id, buildJsonObject { put("tools", tools) })
+}
+
+private suspend fun handleToolsCall(id: JsonElement?, params: JsonObject, deps: McpDependencies): String {
+    val name = params["name"]?.jsonPrimitive?.contentOrNull
+        ?: return jsonRpcError(id, -32602, "Missing required parameter: name")
+    val arguments = params["arguments"]?.jsonObject ?: JsonObject(emptyMap())
+
+    val sessionId = arguments["sessionId"]?.jsonPrimitive?.contentOrNull
+    // getOrCreate(null) creates a temporary session backed by demo activity data
+    val session = deps.sessionRegistry.getOrCreate(sessionId)
+
+    val text = try {
+        when (name) {
+            "get_training_load" -> {
+                val days = arguments["days"]?.jsonPrimitive?.intOrNull?.coerceIn(7, 120) ?: 45
+                val maxHr = arguments["maxHr"]?.jsonPrimitive?.intOrNull?.coerceIn(120, 230) ?: 190
+                val restingHr = arguments["restingHr"]?.jsonPrimitive?.intOrNull?.coerceIn(30, 90) ?: 50
+                val (source, snapshot, _) = deps.loadProvider(session.activityRepository, days, maxHr, restingHr)
+                buildJsonObject {
+                    put("source", source)
+                    put("date", snapshot.date.toString())
+                    put("ctl", snapshot.ctl)
+                    put("atl", snapshot.atl)
+                    put("tsb", snapshot.tsb)
+                    put("acwr", snapshot.acwr)
+                    put("monotony", snapshot.monotony)
+                    put("ctlRampRate", snapshot.ctlRampRate)
+                    put("recentVolumeMinutes", snapshot.recentVolumeMinutes)
+                    put("spike10", snapshot.spike10)
+                    put("strain10", snapshot.strain10)
+                    put("series", buildJsonArray {
+                        snapshot.series.forEach { pt ->
+                            add(buildJsonObject {
+                                put("date", pt.date.toString())
+                                put("trimp", pt.trimp)
+                                put("ctl", pt.ctl)
+                                put("atl", pt.atl)
+                                put("tsb", pt.tsb)
+                            })
+                        }
+                    })
+                }.toString()
+            }
+
+            "get_athlete_profile" -> {
+                val state = session.dashboardState.read()
+                buildJsonObject {
+                    put("sportFocus", state.onboarding.sportFocus)
+                    put("targetEventName", state.onboarding.targetEventName)
+                    put("targetEventDate", state.onboarding.targetEventDate)
+                    put("maxHr", state.maxHr)
+                    put("restingHr", state.restingHr)
+                    put("onboardingCompleted", state.onboarding.completed)
+                }.toString()
+            }
+
+            "get_workout_plan" -> {
+                val state = session.dashboardState.read()
+                val workout = state.latestWorkout
+                if (workout != null) {
+                    buildJsonObject {
+                        put("session", workout.session)
+                        put("coachReasoning", workout.coachReasoning)
+                        put("generatedAt", state.generatedAt?.toString())
+                        put("source", state.source)
+                    }.toString()
+                } else {
+                    buildJsonObject { put("workout", JsonNull) }.toString()
+                }
+            }
+
+            else -> return jsonRpcError(id, -32602, "Unknown tool: $name")
+        }
+    } catch (e: Exception) {
+        return jsonRpcSuccess(
+            id,
+            buildJsonObject {
+                put("content", buildJsonArray {
+                    add(buildJsonObject { put("type", "text"); put("text", "Error calling tool '$name': ${e.message ?: e::class.simpleName}") })
+                })
+                put("isError", true)
+            }
+        )
+    }
+
+    return jsonRpcSuccess(
+        id,
+        buildJsonObject {
+            put("content", buildJsonArray {
+                add(buildJsonObject { put("type", "text"); put("text", text) })
+            })
+        }
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+private fun toolDef(name: String, description: String, properties: JsonObject): JsonObject =
+    buildJsonObject {
+        put("name", name)
+        put("description", description)
+        put("inputSchema", buildJsonObject {
+            put("type", "object")
+            put("properties", properties)
+        })
+    }
+
+private fun prop(type: String, description: String): JsonObject =
+    buildJsonObject {
+        put("type", type)
+        put("description", description)
+    }
+
+private fun jsonRpcSuccess(id: JsonElement?, result: JsonObject): String =
+    buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("id", id ?: JsonNull)
+        put("result", result)
+    }.toString()
+
+private fun jsonRpcError(id: JsonElement?, code: Int, message: String): String =
+    buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("id", id ?: JsonNull)
+        put("error", buildJsonObject {
+            put("code", code)
+            put("message", message)
+        })
+    }.toString()

--- a/app/src/main/kotlin/com/endurocoach/routes/McpRoutes.kt
+++ b/app/src/main/kotlin/com/endurocoach/routes/McpRoutes.kt
@@ -164,6 +164,18 @@ private suspend fun handleToolsCall(id: JsonElement?, params: JsonObject, deps: 
                     put("recentVolumeMinutes", snapshot.recentVolumeMinutes)
                     put("spike10", snapshot.spike10)
                     put("strain10", snapshot.strain10)
+                    put("daysSinceLastHardSession", snapshot.daysSinceLastHardSession)
+                    put("recentSessions", buildJsonArray {
+                        snapshot.recentSessions.forEach { session ->
+                            add(buildJsonObject {
+                                put("date", session.date.toString())
+                                put("name", session.name)
+                                put("durationMinutes", session.durationMinutes)
+                                put("trimp", session.trimp)
+                                put("intensity", session.intensity)
+                            })
+                        }
+                    })
                     put("series", buildJsonArray {
                         snapshot.series.forEach { pt ->
                             add(buildJsonObject {

--- a/core-domain/src/main/kotlin/com/endurocoach/domain/Models.kt
+++ b/core-domain/src/main/kotlin/com/endurocoach/domain/Models.kt
@@ -47,7 +47,9 @@ data class WorkoutRequest(
     val ctlRampRate: Double,
     val spike10: Double = 1.0,
     val strain10: Double = 0.0,
-    val recentPaceProfile: RecentPaceProfile? = null
+    val recentPaceProfile: RecentPaceProfile? = null,
+    val daysSinceLastHardSession: Int? = null,
+    val recentSessions: List<RecentSessionSummary> = emptyList()
 )
 
 data class WorkoutPlan(
@@ -78,7 +80,17 @@ data class LoadSnapshot(
     val spike10: Double = 1.0,
     /** Foster strain over the last 10 days: mean(last10 TRIMP) × monotony(last10).
      *  Captures accumulated fatigue from both volume and uniformity. */
-    val strain10: Double = 0.0
+    val strain10: Double = 0.0,
+    val daysSinceLastHardSession: Int? = null,
+    val recentSessions: List<RecentSessionSummary> = emptyList()
+)
+
+data class RecentSessionSummary(
+    val date: LocalDate,
+    val name: String,
+    val durationMinutes: Double,
+    val trimp: Double,
+    val intensity: String
 )
 
 /**

--- a/core-metrics/src/main/kotlin/com/endurocoach/metrics/BanisterTrimpCalculator.kt
+++ b/core-metrics/src/main/kotlin/com/endurocoach/metrics/BanisterTrimpCalculator.kt
@@ -22,14 +22,18 @@ class BanisterTrimpCalculator(
     private val maxHeartRate: Int = 190,
     private val restingHeartRate: Int = 50
 ) {
+    enum class SessionIntensity {
+        EASY,
+        TEMPO,
+        HARD
+    }
+
     fun calculate(durationMinutes: Double, avgHeartRate: Int?): Double {
         if (durationMinutes <= 0.0 || avgHeartRate == null) {
             return 0.0
         }
 
-        val reserve = (maxHeartRate - restingHeartRate).coerceAtLeast(1)
-        val hrRatio = ((avgHeartRate - restingHeartRate).toDouble() / reserve)
-            .coerceIn(0.0, 1.0)
+        val hrRatio = hrReserveRatio(avgHeartRate)
 
         val zoneWeight = when {
             hrRatio < 0.68 -> 1.0
@@ -39,5 +43,21 @@ class BanisterTrimpCalculator(
         }
 
         return durationMinutes * hrRatio * zoneWeight
+    }
+
+    fun classifySession(avgHeartRate: Int?): SessionIntensity {
+        val hrRatio = hrReserveRatio(avgHeartRate)
+        return when {
+            hrRatio >= 0.82 -> SessionIntensity.HARD
+            hrRatio >= 0.68 -> SessionIntensity.TEMPO
+            else -> SessionIntensity.EASY
+        }
+    }
+
+    private fun hrReserveRatio(avgHeartRate: Int?): Double {
+        if (avgHeartRate == null) return 0.0
+        val reserve = (maxHeartRate - restingHeartRate).coerceAtLeast(1)
+        return ((avgHeartRate - restingHeartRate).toDouble() / reserve)
+            .coerceIn(0.0, 1.0)
     }
 }

--- a/core-metrics/src/main/kotlin/com/endurocoach/metrics/LoadSeriesService.kt
+++ b/core-metrics/src/main/kotlin/com/endurocoach/metrics/LoadSeriesService.kt
@@ -3,13 +3,14 @@ package com.endurocoach.metrics
 import com.endurocoach.domain.Activity
 import com.endurocoach.domain.LoadPoint
 import com.endurocoach.domain.LoadSnapshot
+import com.endurocoach.domain.RecentSessionSummary
 import java.time.LocalDate
 import kotlin.math.exp
 import kotlin.math.sqrt
 
 data class LoadSettings(
     val ctlTimeConstantDays: Double = 42.0,
-    val atlTimeConstantDays: Double = 7.0,
+    val atlTimeConstantDays: Double = 5.0,
     /** Number of days used to seed CTL/ATL from the initial training data. */
     val seedDays: Int = 7
 )
@@ -116,6 +117,26 @@ class LoadSeriesService(
             }
         } else 0.0
 
+        val recentSessions = activities
+            .filter { !it.date.isBefore(endDate.minusDays(6)) && !it.date.isAfter(endDate) }
+            .sortedByDescending { it.date }
+            .map {
+                val intensity = trimpCalculator.classifySession(it.avgHeartRate).name
+                RecentSessionSummary(
+                    date = it.date,
+                    name = it.name?.takeIf { value -> value.isNotBlank() } ?: (it.type ?: "Activity"),
+                    durationMinutes = it.durationMinutes,
+                    trimp = trimpCalculator.calculate(it.durationMinutes, it.avgHeartRate),
+                    intensity = intensity
+                )
+            }
+
+        val daysSinceLastHardSession = activities
+            .filter { !it.date.isBefore(endDate.minusDays(13)) && !it.date.isAfter(endDate) }
+            .sortedByDescending { it.date }
+            .firstOrNull { trimpCalculator.classifySession(it.avgHeartRate) == BanisterTrimpCalculator.SessionIntensity.HARD }
+            ?.let { java.time.temporal.ChronoUnit.DAYS.between(it.date, endDate).toInt() }
+
         return LoadSnapshot(
             date = latest.date,
             ctl = latest.ctl,
@@ -127,7 +148,9 @@ class LoadSeriesService(
             ctlRampRate = ctlRampRate,
             series = series,
             spike10 = spike10,
-            strain10 = strain10
+            strain10 = strain10,
+            daysSinceLastHardSession = daysSinceLastHardSession,
+            recentSessions = recentSessions
         )
     }
 

--- a/core-metrics/src/test/kotlin/com/endurocoach/metrics/BanisterTrimpCalculatorTest.kt
+++ b/core-metrics/src/test/kotlin/com/endurocoach/metrics/BanisterTrimpCalculatorTest.kt
@@ -68,4 +68,15 @@ class BanisterTrimpCalculatorTest {
         val trimpHigh = calc.calculate(60.0, 170)
         assertTrue(trimpHigh > trimpLow, "Higher HR should produce higher TRIMP")
     }
+
+    @Test
+    fun classifySessionUsesZoneBoundaries() {
+        // HRR reserve = 140 (190-50)
+        // 68% boundary => 145.2 bpm; 82% boundary => 164.8 bpm
+        assertEquals(BanisterTrimpCalculator.SessionIntensity.EASY, calc.classifySession(145))
+        assertEquals(BanisterTrimpCalculator.SessionIntensity.TEMPO, calc.classifySession(146))
+        assertEquals(BanisterTrimpCalculator.SessionIntensity.TEMPO, calc.classifySession(164))
+        assertEquals(BanisterTrimpCalculator.SessionIntensity.HARD, calc.classifySession(165))
+        assertEquals(BanisterTrimpCalculator.SessionIntensity.HARD, calc.classifySession(180))
+    }
 }

--- a/core-metrics/src/test/kotlin/com/endurocoach/metrics/LoadSeriesServiceTest.kt
+++ b/core-metrics/src/test/kotlin/com/endurocoach/metrics/LoadSeriesServiceTest.kt
@@ -130,4 +130,35 @@ class LoadSeriesServiceTest {
             "TSB should not be deeply negative for consistent training, got ${snapshot.tsb}"
         )
     }
+
+    @Test
+    fun snapshotCapturesDaysSinceLastHardSession() {
+        val endDate = LocalDate.of(2025, 6, 20)
+        val activities = listOf(
+            Activity(
+                date = endDate.minusDays(2),
+                durationMinutes = 50.0,
+                avgHeartRate = 171, // HARD (>=82% HRR)
+                name = "VO2 session"
+            ),
+            Activity(
+                date = endDate.minusDays(1),
+                durationMinutes = 40.0,
+                avgHeartRate = 130,
+                name = "Easy run"
+            ),
+            Activity(
+                date = endDate,
+                durationMinutes = 35.0,
+                avgHeartRate = 128,
+                name = "Recovery jog"
+            )
+        )
+
+        val snapshot = service.buildSnapshot(activities = activities, days = 14, endDate = endDate)
+        assertEquals(2, snapshot.daysSinceLastHardSession)
+        assertTrue(snapshot.recentSessions.isNotEmpty())
+        assertEquals("HARD", snapshot.recentSessions.first { it.name == "VO2 session" }.intensity)
+        assertEquals("EASY", snapshot.recentSessions.first { it.name == "Recovery jog" }.intensity)
+    }
 }

--- a/infra-llm/src/main/kotlin/com/endurocoach/llm/GeminiClient.kt
+++ b/infra-llm/src/main/kotlin/com/endurocoach/llm/GeminiClient.kt
@@ -97,19 +97,32 @@ You are an elite-level endurance running coach with deep expertise in periodisat
 - Banister impulse-response model (CTL/ATL/TSB)
 - Gabbett's Acute:Chronic Workload Ratio (ACWR) for injury risk management
 - Seiler's polarised training model (80/20 intensity distribution)
+- Canova marathon-specific aerobic progression and hard/easy session sequencing
+- Daniels' Running Formula intensity distribution (E, M, T, I, R)
+- Norwegian threshold principles (high-quality threshold work, easy days truly easy)
 - Foster's training monotony for load variation
 - Mujika & Busso's taper and peaking research
 - Skiba & Billat lactate threshold models: LT1 (first lactate threshold / aerobic threshold, ~75% HRR) is the all-day aerobic ceiling — easy runs should stay below it; LT2 (lactate/anaerobic threshold, ~87% HRR) is the comfortably-hard ceiling for tempo and threshold work — interval efforts target this zone or above
 
 Behavioural rules:
 - Be direct, precise, and authoritative. No filler praise, hedging, or sycophantic tone.
-- Interpret training load data in context: a negative TSB during a build block is EXPECTED and PRODUCTIVE. Do not catastrophise about normal training fatigue.
+- Interpret TSB with context and clear bands:
+    - TSB < -10: heavy fatigue; prescribe recovery/easy only.
+    - TSB -10 to -5: moderate fatigue; no high-intensity quality.
+    - TSB -5 to +5: normal productive training zone.
+    - TSB > +5: freshness supports quality when other signals agree.
 - ACWR 0.8–1.3 is the sweet spot (Gabbett 2016). Only flag concern if ACWR > 1.5 or if it has been elevated for > 7–10 days.
 - Monotony > 2.0 warrants recommending more hard/easy polarisation, but is not an emergency.
 - Every prescription must be backed by a clear physiological or periodisation rationale.
 - If the athlete genuinely needs rest, say so plainly — but distinguish between productive fatigue (functional overreaching) and problematic fatigue (non-functional overreaching).
 - Treat the athlete as a serious, coachable adult who wants honest, actionable guidance.
-- Consider the Norwegian method / Maffetone principles for easy-day prescriptions.
+- Hard-session recency rule (strict):
+    - Never prescribe a quality/hard workout if the last HARD session (Zone 3+, >=82% HRR) was < 48 hours ago.
+    - If last HARD session was < 72 hours ago and ATL > CTL, prescribe recovery/easy only.
+- Always blend these method anchors into your decision, regardless of coaching philosophy:
+    - Canova: event-specific aerobic strength and controlled quality; protect easy days after hard sessions.
+    - Daniels: choose stress by adaptation target (E/M/T/I/R); avoid stacking I/R efforts without recovery.
+    - Norwegian: threshold work should stay near threshold (not above); keep easy runs genuinely easy.
 
 Pace range requirements (MANDATORY):
 - Every segment (warmup, main_set, cooldown) MUST include a pace range in the format M:SS–M:SS/km.
@@ -141,7 +154,8 @@ Athlete readiness:
 - Coaching philosophy: ${request.checkIn.coachingPhilosophy}
 
 Training load state:
-- TSB (Training Stress Balance): ${"%.1f".format(request.currentTsb)} — negative during build blocks is normal and expected per Mujika & Busso
+- Last hard session (Zone 3+): ${formatDaysSinceHard(request.daysSinceLastHardSession)}
+- TSB (Training Stress Balance): ${"%.1f".format(request.currentTsb)}
 - CTL (Chronic Training Load / fitness): ${"%.1f".format(request.currentCtl)}
 - ATL (Acute Training Load / fatigue): ${"%.1f".format(request.currentAtl)}
 - ACWR (Acute:Chronic Workload Ratio): ${"%.2f".format(request.acwr)} — Gabbett sweet spot is 0.8–1.3; concern above 1.5
@@ -151,6 +165,9 @@ Training load state:
 - 10-day Spike Ratio: ${"%.2f".format(request.spike10)} — ratio of 10-day rolling load to the full-window daily average baseline; above 1.3 warrants monitoring, above 1.5 is a concern even if standard ACWR looks safe
 - 10-day Strain (Foster): ${"%.0f".format(request.strain10)} — accumulated load × monotony over 10 days; above 700 is high and suggests the athlete is carrying both volume and insufficient variation
 
+Recent training (last 7 days):
+${buildRecentSessionsBlock(request)}
+
 ${buildPaceProfileBlock(request)}
 
 ${buildRaceFocusBlock(request.checkIn.raceDistance)}
@@ -159,6 +176,30 @@ Prescription requirements:
 - session: Write the full workout as a single block of flowing prose. For quality sessions (intervals, tempo, threshold work): open with a brief warm-up in the same text (e.g. "After a 10-min easy jog at 5:50/km..."), describe the main effort with specific intervals, recoveries, and pace ranges (M:SS–M:SS/km), then close with a brief cool-down note (e.g. "...followed by 5 min easy to finish"). For easy or recovery runs: describe only the run with pace range; do not mention warm-up or cool-down.
 - coach_reasoning: Justify this exact session by referencing the athlete's TSB, ACWR, CTL trend, monotony, subjective readiness, coaching philosophy, and race focus. State which physiological adaptation this session targets and how the prescribed paces align with LT1/LT2 zones. If ACWR is in the sweet spot, say so — don't look for problems that aren't there.
 """.trimIndent()
+    }
+
+    private fun formatDaysSinceHard(daysSinceLastHardSession: Int?): String {
+        return when (daysSinceLastHardSession) {
+            null -> "No hard session recorded in the last 14 days"
+            0 -> "Today"
+            1 -> "1 day ago"
+            else -> "$daysSinceLastHardSession days ago"
+        }
+    }
+
+    private fun buildRecentSessionsBlock(request: WorkoutRequest): String {
+        if (request.recentSessions.isEmpty()) {
+            return "- No activities recorded in the last 7 days"
+        }
+
+        return request.recentSessions.joinToString("\n") { session ->
+            val dayLabel = when (val daysAgo = java.time.temporal.ChronoUnit.DAYS.between(session.date, java.time.LocalDate.now()).toInt()) {
+                0 -> "today"
+                1 -> "1 day ago"
+                else -> "$daysAgo days ago"
+            }
+            "- ${session.date} ($dayLabel): ${session.name}, ${"%.0f".format(session.durationMinutes)} min, TRIMP ${"%.1f".format(session.trimp)}, ${session.intensity}"
+        }
     }
 
     private fun buildPaceProfileBlock(request: WorkoutRequest): String {

--- a/infra-llm/src/main/kotlin/com/endurocoach/llm/PerplexityClient.kt
+++ b/infra-llm/src/main/kotlin/com/endurocoach/llm/PerplexityClient.kt
@@ -50,6 +50,13 @@ Behavioural rules:
 - Do not soften bad news. If load state indicates accumulated fatigue, state the risk and adjust the session accordingly.
 - Treat the athlete as a serious, coachable adult who wants honest, actionable guidance.
 - Lactate threshold theory: LT1 (aerobic threshold, ~75% HRR) is the all-day pace ceiling for easy running; LT2 (lactate/anaerobic threshold, ~87% HRR) is the comfortably-hard ceiling for tempo work. Intervals target LT2 or above.
+- Hard-session recency rule (strict):
+    - Never prescribe a quality/hard workout if the last HARD session (Zone 3+, >=82% HRR) was < 48 hours ago.
+    - If last HARD session was < 72 hours ago and ATL > CTL, prescribe recovery/easy only.
+- Method anchors (always apply):
+    - Canova: event-specific aerobic quality with disciplined hard/easy sequencing.
+    - Daniels: use E/M/T/I/R intensity intent and avoid stacking I/R quality back-to-back.
+    - Norwegian: threshold work near threshold; easy days genuinely easy.
 
 Output contract:
 - Return exactly one JSON object with these two keys and no others: session, coach_reasoning.
@@ -72,10 +79,14 @@ Athlete readiness:
 - Coaching philosophy: ${request.checkIn.coachingPhilosophy}
 
 Training load state (Banister impulse-response model):
+- Last hard session (Zone 3+): ${formatDaysSinceHard(request.daysSinceLastHardSession)}
 - TSB (Training Stress Balance): ${"%.2f".format(request.currentTsb)}
 - CTL (Chronic Training Load / fitness): ${"%.2f".format(request.currentCtl)}
 - ATL (Acute Training Load / fatigue): ${"%.2f".format(request.currentAtl)}
 - Recent 7-day volume: ${"%.1f".format(request.recentVolumeMinutes)} minutes
+
+Recent training (last 7 days):
+${buildRecentSessionsBlock(request)}
 
 ${buildPaceProfileBlock(request)}
 
@@ -85,6 +96,25 @@ Prescription requirements:
 - session: Write the full workout as a single block of flowing prose. For quality sessions: open with a brief warm-up note, describe the main effort with specific pace ranges (M:SS–M:SS/km), then close with a brief cool-down note. For easy or recovery runs: describe only the run; do not mention warm-up or cool-down.
 - coach_reasoning: Justify this exact session referencing load state, readiness, coaching philosophy, race focus, and how prescribed paces align with LT1/LT2 zones.
 """.trimIndent()
+    }
+
+    private fun formatDaysSinceHard(daysSinceLastHardSession: Int?): String {
+        return when (daysSinceLastHardSession) {
+            null -> "No hard session recorded in the last 14 days"
+            0 -> "Today"
+            1 -> "1 day ago"
+            else -> "$daysSinceLastHardSession days ago"
+        }
+    }
+
+    private fun buildRecentSessionsBlock(request: WorkoutRequest): String {
+        if (request.recentSessions.isEmpty()) {
+            return "- No activities recorded in the last 7 days"
+        }
+
+        return request.recentSessions.joinToString("\n") { session ->
+            "- ${session.date}: ${session.name}, ${"%.0f".format(session.durationMinutes)} min, TRIMP ${"%.1f".format(session.trimp)}, ${session.intensity}"
+        }
     }
 
     private fun buildPaceProfileBlock(request: WorkoutRequest): String {


### PR DESCRIPTION
## Summary
- add hard-session recency signals to load snapshot and API outputs
- tighten dashboard freshness messaging when hard runs are within 48-72h
- enrich workout prompts with recent sessions and Canova/Daniels/Norwegian guidance
- tune ATL responsiveness and add targeted metrics tests

## Validation
- ./gradlew test --no-daemon
